### PR TITLE
feat: add generic interface

### DIFF
--- a/components/common/LabelInput.tsx
+++ b/components/common/LabelInput.tsx
@@ -1,16 +1,23 @@
 import Input, { type Props as InputProps } from './Input';
 import styled, { css } from 'styled-components';
-import { forwardRef, useState } from 'react';
+import { forwardRef, Ref, useState } from 'react';
 import { colors } from '@/lib/colors';
 import ErrorMessage from './ErrorMessage';
+import { FieldValues, FieldPath } from 'react-hook-form';
 
-interface Props extends InputProps {
+interface Props<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> extends InputProps {
   label: string;
   errorMessage?: string | false;
 }
 
 const LabelInput = forwardRef<HTMLInputElement, Props>(
-  ({ label, errorMessage, ...rest }: Props, ref) => {
+  <TFieldValues extends FieldValues>(
+    { label, errorMessage, defaultValue, ...rest }: Props<TFieldValues>,
+    ref: Ref<HTMLInputElement> | undefined,
+  ) => {
     const [focused, setFocused] = useState(false);
 
     const onFocus = () => {
@@ -27,7 +34,7 @@ const LabelInput = forwardRef<HTMLInputElement, Props>(
           <Label focused={focused}>{label}</Label>
           <ErrorMessage errorMessage={errorMessage} />
         </Block>
-        <Input {...rest} onFocus={onFocus} onBlur={onBlur} ref={ref} />
+        <Input defaultValue={defaultValue} {...rest} onFocus={onFocus} onBlur={onBlur} ref={ref} />
       </Wrapper>
     );
   },

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -8,7 +8,7 @@ export interface CreateAuctionResponse {
 }
 
 export interface Auctions {
-  pages: any;
+  pages: { content: AuctionContent[] }[];
   totalElements: number;
   totalPages: number;
   sort: Sort;


### PR DESCRIPTION
제네릭 인터페이스 적용하여 제네릭을 react-hook-form 시그니쳐 타입에만 한정시키기

이미 forwardRef 가 있던 자리여서 적용하기어 어려운데 이방법이 맞는지는 좀 더 확인 필요